### PR TITLE
Fixes issue with closing div for nested list fields

### DIFF
--- a/src/InputMarkup.php
+++ b/src/InputMarkup.php
@@ -144,11 +144,10 @@ class InputMarkup extends StdObject {
 
         if ($this->input->isNested()) {
             $output .= $this->buildOptionsList($this->input->getValues(), array($this, $option_func), 0, true);
-            return $output;
-        }
-
-        foreach ($this->input->getValues() as $value => $label) {
-            $output .= call_user_func(array($this,$option_func), $value, $label);
+        } else {
+            foreach ($this->input->getValues() as $value => $label) {
+                $output .= call_user_func(array($this,$option_func), $value, $label);
+            }
         }
 
         $output .= '</div>';


### PR DESCRIPTION
Nested list fields were returning before outputting the closing </div> for the element, causing validation issues and in some cases breaking the DOM. Changing the control structure saves adding another "$output .= '</div>';" before the earlier return statement.
